### PR TITLE
dockerfile - include libdav1d for AV1 decoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
 		cmake \
 		g++ \
 		gcc \
+		libdav1d-dev \
 		pkg-config \
 		make \
 		nasm \	
@@ -59,7 +60,7 @@ RUN \
 	wget https://github.com/FFmpeg/FFmpeg/archive/refs/heads/master.tar.gz  && \
 	tar -xzf ${FFMPEG_version}.tar.gz && \
 	cd FFmpeg-${FFMPEG_version} && \
-	./configure --enable-libvmaf --enable-version3 --enable-shared && \
+	./configure --enable-libvmaf --enable-version3 --enable-shared --enable-libdav1d && \
 	make -j4 && \
 	make install && \
 	rm -rf /tmp/ffmpeg
@@ -78,6 +79,8 @@ RUN \
 	export TZ='UTC' && \
 	ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
 	apt-get update -yqq && \
+	apt-get install -y --no-install-recommends \
+		dav1d && \
 	apt-get autoremove -y && \
     apt-get clean -y && \
 	pip3 install --user ffmpeg-progress-yield


### PR DESCRIPTION
The current Docker image for easyVmaf does not build ffmpeg with `--enable-libdav1d`, which means it can't be used to evaluate AV1 files. Since easyVmaf aims to be a one-stop shop for VMAF calculations, and AV1 is gaining in popularity, we should support AV1 out of the box.

This PR installs `libdav1d-dev` in the ffmpeg build environment, builds with `--enable-libdav1d`, and installs `dav1d` in the release environment.

If you'd like to try out this patch, I've published a multi-arch tag [on Docker Hub](https://hub.docker.com/r/wlritchi/easyvmaf) as `wlritchi/easyvmaf:support-av1-decode`.

<details>
<summary>For reference, the error message when trying to use an AV1 file with the Docker image before this PR:</summary>

```
...
=======================================
[easyVmaf] Getting frames info... /vdir/my-av1-file.mkv
=======================================
[av1 @ 0x55b430fbe9c0] No sequence header available.
[av1 @ 0x55b430fbe9c0] Your platform doesn't suppport hardware accelerated AV1 decoding.
[av1 @ 0x55b430fbe9c0] Failed to get pixel format.
[av1 @ 0x55b430fbe9c0] Missing Sequence Header.
    Last message repeated 148 times
[matroska,webm @ 0x55b430fbaa00] Could not find codec parameters for stream 0 (Video: av1 (Main), none(tv, bt709, progressive), 1280x720 [SAR 1:1 DAR 16:9]): unspecified pixel format
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
Input #0, matroska,webm, from '/vdir/my-av1-file.mkv':
  Metadata:
    COMPATIBLE_BRANDS: isomiso2avc1mp41
    MAJOR_BRAND     : isom
    MINOR_VERSION   : 512
    ENCODER         : Lavf59.16.100
  Duration: 02:59:12.34, start: 0.000000, bitrate: 527 kb/s
  Stream #0:0: Video: av1 (Main), none(tv, bt709, progressive), 1280x720 [SAR 1:1 DAR 16:9], 30 fps, 30 tbr, 1k tbn (default)
    Metadata:
      HANDLER_NAME    : VideoHandler
      VENDOR_ID       : [0][0][0][0]
      ENCODER         : Lavc59.18.100 libaom-av1
      DURATION        : 02:59:11.400000000
  Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp (default)
    Metadata:
      HANDLER_NAME    : SoundHandler
      VENDOR_ID       : [0][0][0][0]
      DURATION        : 02:59:12.341000000
[av1 @ 0x55b430fcc740] No sequence header available.
[av1 @ 0x55b430fcc740] Your platform doesn't suppport hardware accelerated AV1 decoding.
[av1 @ 0x55b430fcc740] Failed to get pixel format.
[av1 @ 0x55b430fcc740] Missing Sequence Header.
Traceback (most recent call last):
  File "easyVmaf.py", line 149, in <module>
    myVmaf = vmaf(main, reference, loglevel=loglevel, subsample=n_subsample, model=model, phone=phone,
  File "/app/easyVmaf/Vmaf.py", line 124, in __init__
    self.main = video(mainSrc, self.loglevel)
  File "/app/easyVmaf/Vmaf.py", line 47, in __init__
    self.getFramesInfo()
  File "/app/easyVmaf/Vmaf.py", line 94, in getFramesInfo
    self._updateFramesSummary()
  File "/app/easyVmaf/Vmaf.py", line 62, in _updateFramesSummary
    if int(round(self.interlacedFrames/self.totalFrames)):
ZeroDivisionError: division by zero
```
</details>