### PR TITLE
Dynamic paths for ff* utils

### DIFF
--- a/FFmpeg.py
+++ b/FFmpeg.py
@@ -56,7 +56,7 @@ class FFprobe:
         - getFramesInfo()
         - getPacketsInfo()
     '''
-    cmd = config.ffprobe
+    cmd = os.environ.get('FFPROBE', config.ffprobe)
 
     def __init__(self, videoSrc, loglevel="info"):
         self.videoSrc = videoSrc
@@ -103,7 +103,7 @@ class FFmpegQos:
     Class to interact with FFmpeg QoS Filters: PSNR and VMAF. 
     Particullary, it interacts with libvmaf library through lavfi filter
     '''
-    cmd = config.ffmpeg
+    cmd = os.environ.get('FFMPEG', config.ffmpeg)
 
     def __init__(self,  main, ref, loglevel="info"):
         self.loglevel = loglevel

--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+import shutil
 
-ffmpeg = '/usr/local/bin/ffmpeg'
-ffprobe = '/usr/local/bin/ffprobe'
+ffmpeg = shutil.which("ffmpeg")
+ffprobe = shutil.which("ffprobe")


### PR DESCRIPTION
This PR uses `shutil.which()` to lookup the paths of `ffmpeg` and `ffprobe`.

Homebrew on Apple Silicon Macs changed installation directory to `/opt/homebrew`, which makes easyVmaf break on macOS.